### PR TITLE
Allow skipping existence checks in PrefixTransfer

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+This adds a new argument to `Transfer.transfer()` and `PrefixTransfer.transferPrefix()`.
+
+If you set `checkForExisting = false`, the transfer classes will skip checking whether an object already exists under a matching key.  This can be useful in S3, when making a GET to an object before it exists can [change the consistency](https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html):
+
+> Amazon S3 provides read-after-write consistency for PUTS of new objects in your S3 bucket in all Regions with one caveat. The caveat is that if you make a HEAD or GET request to a key name before the object is created, then create the object shortly after that, a subsequent GET might not return the object due to eventual consistency.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/transfer/PrefixTransfer.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/transfer/PrefixTransfer.scala
@@ -18,7 +18,8 @@ trait PrefixTransfer[Prefix, Location] extends Logging {
   private def copyPrefix(
     iterator: Iterable[Location],
     srcPrefix: Prefix,
-    dstPrefix: Prefix
+    dstPrefix: Prefix,
+    checkForExisting: Boolean
   ): Either[PrefixTransferFailure, PrefixTransferSuccess] = {
     var successes = 0
     var failures = 0
@@ -36,7 +37,9 @@ trait PrefixTransfer[Prefix, Location] extends Logging {
                 dst = buildDstLocation(
                   srcPrefix = srcPrefix,
                   dstPrefix = dstPrefix,
-                  srcLocation = srcLocation)
+                  srcLocation = srcLocation
+                ),
+                checkForExisting = checkForExisting
               )
             )
           }
@@ -60,14 +63,20 @@ trait PrefixTransfer[Prefix, Location] extends Logging {
 
   def transferPrefix(
     srcPrefix: Prefix,
-    dstPrefix: Prefix
+    dstPrefix: Prefix,
+    checkForExisting: Boolean = true
   ): Either[TransferFailure, PrefixTransferSuccess] = {
     listing.list(srcPrefix) match {
       case Left(error) =>
         Left(PrefixTransferListingFailure(srcPrefix, error.e))
 
       case Right(iterable) =>
-        copyPrefix(iterable, srcPrefix, dstPrefix)
+        copyPrefix(
+          iterator = iterable,
+          srcPrefix = srcPrefix,
+          dstPrefix = dstPrefix,
+          checkForExisting = checkForExisting
+        )
     }
   }
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/transfer/Transfer.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/transfer/Transfer.scala
@@ -2,5 +2,15 @@ package uk.ac.wellcome.storage.transfer
 
 trait Transfer[Location] {
   def transfer(src: Location,
-               dst: Location): Either[TransferFailure, TransferSuccess]
+               dst: Location,
+               checkForExisting: Boolean = true): Either[TransferFailure, TransferSuccess] =
+    if (checkForExisting) {
+      transferWithCheckForExisting(src, dst)
+    } else {
+      transferWithOverwrites(src, dst)
+    }
+
+  protected def transferWithCheckForExisting(src: Location, dst: Location): Either[TransferFailure, TransferSuccess]
+
+  protected def transferWithOverwrites(src: Location, dst: Location): Either[TransferFailure, TransferSuccess]
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/transfer/Transfer.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/transfer/Transfer.scala
@@ -1,16 +1,19 @@
 package uk.ac.wellcome.storage.transfer
 
 trait Transfer[Location] {
-  def transfer(src: Location,
-               dst: Location,
-               checkForExisting: Boolean = true): Either[TransferFailure, TransferSuccess] =
+  def transfer(src: Location, dst: Location, checkForExisting: Boolean = true)
+    : Either[TransferFailure, TransferSuccess] =
     if (checkForExisting) {
       transferWithCheckForExisting(src, dst)
     } else {
       transferWithOverwrites(src, dst)
     }
 
-  protected def transferWithCheckForExisting(src: Location, dst: Location): Either[TransferFailure, TransferSuccess]
+  protected def transferWithCheckForExisting(
+    src: Location,
+    dst: Location): Either[TransferFailure, TransferSuccess]
 
-  protected def transferWithOverwrites(src: Location, dst: Location): Either[TransferFailure, TransferSuccess]
+  protected def transferWithOverwrites(
+    src: Location,
+    dst: Location): Either[TransferFailure, TransferSuccess]
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/transfer/memory/MemoryTransfer.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/transfer/memory/MemoryTransfer.scala
@@ -6,7 +6,9 @@ import uk.ac.wellcome.storage.transfer._
 trait MemoryTransfer[Ident, T]
     extends Transfer[Ident]
     with MemoryStoreBase[Ident, T] {
-  override def transferWithCheckForExisting(src: Ident, dst: Ident): Either[TransferFailure, TransferSuccess] =
+  override def transferWithCheckForExisting(
+    src: Ident,
+    dst: Ident): Either[TransferFailure, TransferSuccess] =
     (entries.get(src), entries.get(dst)) match {
       case (Some(srcT), Some(dstT)) if srcT == dstT =>
         Right(TransferNoOp(src, dst))
@@ -19,7 +21,9 @@ trait MemoryTransfer[Ident, T]
         Left(TransferSourceFailure(src, dst))
     }
 
-  override def transferWithOverwrites(src: Ident, dst: Ident): Either[TransferFailure, TransferSuccess] =
+  override def transferWithOverwrites(
+    src: Ident,
+    dst: Ident): Either[TransferFailure, TransferSuccess] =
     entries.get(src) match {
       case Some(srcT) =>
         entries = entries ++ Map(dst -> srcT)

--- a/storage/src/main/scala/uk/ac/wellcome/storage/transfer/memory/MemoryTransfer.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/transfer/memory/MemoryTransfer.scala
@@ -6,8 +6,7 @@ import uk.ac.wellcome.storage.transfer._
 trait MemoryTransfer[Ident, T]
     extends Transfer[Ident]
     with MemoryStoreBase[Ident, T] {
-  override def transfer(src: Ident,
-                        dst: Ident): Either[TransferFailure, TransferSuccess] =
+  override def transferWithCheckForExisting(src: Ident, dst: Ident): Either[TransferFailure, TransferSuccess] =
     (entries.get(src), entries.get(dst)) match {
       case (Some(srcT), Some(dstT)) if srcT == dstT =>
         Right(TransferNoOp(src, dst))
@@ -17,6 +16,16 @@ trait MemoryTransfer[Ident, T]
         entries = entries ++ Map(dst -> srcT)
         Right(TransferPerformed(src, dst))
       case (None, _) =>
+        Left(TransferSourceFailure(src, dst))
+    }
+
+  override def transferWithOverwrites(src: Ident, dst: Ident): Either[TransferFailure, TransferSuccess] =
+    entries.get(src) match {
+      case Some(srcT) =>
+        entries = entries ++ Map(dst -> srcT)
+        Right(TransferPerformed(src, dst))
+
+      case None =>
         Left(TransferSourceFailure(src, dst))
     }
 }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/transfer/memory/MemoryPrefixTransferTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/transfer/memory/MemoryPrefixTransferTest.scala
@@ -97,7 +97,8 @@ class MemoryPrefixTransferTest
       new InnerMemoryPrefixTransfer(store.entries) {
         override def transfer(
           src: String,
-          dst: String): Either[TransferFailure, TransferSuccess] =
+          dst: String,
+          checkForExisting: Boolean = true): Either[TransferFailure, TransferSuccess] =
           Left(TransferSourceFailure(src, dst))
       }
     )

--- a/storage/src/test/scala/uk/ac/wellcome/storage/transfer/s3/S3PrefixTransferTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/transfer/s3/S3PrefixTransferTest.scala
@@ -92,7 +92,8 @@ class S3PrefixTransferTest
     implicit val transfer: S3Transfer = new S3Transfer() {
       override def transfer(
         src: ObjectLocation,
-        dst: ObjectLocation): Either[TransferFailure, TransferSuccess] =
+        dst: ObjectLocation,
+        checkForExisting: Boolean = true): Either[TransferFailure, TransferSuccess] =
         Left(TransferSourceFailure(src, dst))
     }
 


### PR DESCRIPTION
Part of a fix for https://github.com/wellcomecollection/platform/issues/3897

The issue: the replicator does a GetObject before it does a PutObject for every object, which means the subsequent GetObject in the verifier is at risk of failing.

The fix:

- When the replicator starts, it grabs a lock on the prefix
- It calls ListObjects on the prefix, and if it's empty, it sets `checkForExisting = false` – which means it runs a little cheaper, and we get read-after-write consistency

This should reduce the number of flaky ingests.