### PR TITLE
Add support for tagging resources

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,23 @@
+RELEASE_TYPE: minor
+
+This adds a new trait `Tags` for managing Tags in storage resources.
+It includes in-memory and S3 implementations.
+
+Examples:
+
+```scala
+val s3Tags: new S3Tags()
+
+# Retrieve tags
+s3Tags.get(objectLocation)
+
+# Append tags
+s3Tags.update(objectLocation) { existingTags =>
+  existingTags ++ Map("newKey1" -> "newValue1")
+}
+
+# Replace tags
+s3Tags.update(objectLocation) { _ =>
+  Map("newKey1" -> "newValue1", "newKey2" -> "newValue2")
+}
+```

--- a/storage/src/main/scala/uk/ac/wellcome/storage/StorageError.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/StorageError.scala
@@ -19,7 +19,7 @@ sealed trait BackendError
 sealed trait UpdateError extends StorageError
 sealed trait UpdateFunctionError extends UpdateError
 
-case class UpdateNoSourceError(err: NoVersionExistsError) extends UpdateError {
+case class UpdateNoSourceError(err: NotFoundError) extends UpdateError {
   val e: Throwable = err.e
 }
 case class UpdateReadError(err: ReadError) extends UpdateError {

--- a/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Get.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Get.scala
@@ -1,0 +1,54 @@
+package uk.ac.wellcome.storage.s3
+
+import java.net.SocketTimeoutException
+
+import com.amazonaws.services.s3.model.AmazonS3Exception
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.storage._
+
+import scala.util.{Failure, Success, Try}
+
+object S3Get extends Logging {
+  import RetryOps._
+
+  def get[T](location: ObjectLocation, maxRetries: Int)(
+    getFunction: ObjectLocation => T
+  ): Either[ReadError, T] = {
+    val retryableGet = (getOnce(getFunction)(_)).retry(maxRetries)
+
+    retryableGet(location)
+  }
+
+  private def getOnce[T](getFunction: ObjectLocation => T): ObjectLocation => Either[ReadError, T] =
+    (location: ObjectLocation) =>
+      Try { getFunction(location) } match {
+        case Success(t)   => Right(t)
+        case Failure(err) => Left(buildGetError(err))
+      }
+
+  private def buildGetError(throwable: Throwable): ReadError =
+    throwable match {
+      case exc: AmazonS3Exception
+        if exc.getMessage.startsWith("The specified key does not exist") ||
+          exc.getMessage.startsWith("The specified bucket does not exist") =>
+        DoesNotExistError(exc)
+
+      case exc: AmazonS3Exception
+        if exc.getMessage.startsWith("The specified bucket is not valid") =>
+        StoreReadError(exc)
+
+      case exc: AmazonS3Exception
+        if exc.getMessage.startsWith(
+          "We encountered an internal error. Please try again.") ||
+          exc.getMessage.startsWith("Please reduce your request rate.") =>
+        new StoreReadError(exc) with RetryableError
+
+      case exc: SocketTimeoutException =>
+        new StoreReadError(exc) with RetryableError
+
+      case _ =>
+        warn(s"Unrecognised error inside S3StreamStore.get: $throwable")
+        StoreReadError(throwable)
+    }
+
+}

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/s3/S3StreamReadable.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/s3/S3StreamReadable.scala
@@ -1,15 +1,12 @@
 package uk.ac.wellcome.storage.store.s3
 
-import java.net.SocketTimeoutException
-
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.{AmazonS3Exception, S3Object}
+import com.amazonaws.services.s3.model.S3Object
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.storage._
+import uk.ac.wellcome.storage.s3.S3Get
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.streaming._
-
-import scala.util.{Failure, Success, Try}
 
 trait S3StreamReadable
     extends Readable[ObjectLocation, InputStreamWithLength]
@@ -17,52 +14,18 @@ trait S3StreamReadable
   implicit val s3Client: AmazonS3
   val maxRetries: Int
 
-  import RetryOps._
-
-  override def get(location: ObjectLocation): ReadEither = {
-    val retryableGet = (getOnce _).retry(maxRetries)
-
-    retryableGet(location)
-  }
-
-  private def getOnce(location: ObjectLocation): ReadEither = {
-    Try(s3Client.getObject(location.namespace, location.path)) match {
-      case Success(retrievedObject: S3Object) =>
-        Right(
-          Identified(
-            location,
-            new InputStreamWithLength(
-              retrievedObject.getObjectContent,
-              length = retrievedObject.getObjectMetadata.getContentLength
-            )
+  override def get(location: ObjectLocation): ReadEither =
+    S3Get
+      .get(location, maxRetries = maxRetries) { location: ObjectLocation =>
+        s3Client.getObject(location.namespace, location.path)
+      }
+      .map { retrievedObject: S3Object =>
+        Identified(
+          location,
+          new InputStreamWithLength(
+            retrievedObject.getObjectContent,
+            length = retrievedObject.getObjectMetadata.getContentLength
           )
         )
-      case Failure(err) => Left(buildGetError(err))
-    }
-  }
-
-  private def buildGetError(throwable: Throwable): ReadError =
-    throwable match {
-      case exc: AmazonS3Exception
-          if exc.getMessage.startsWith("The specified key does not exist") ||
-            exc.getMessage.startsWith("The specified bucket does not exist") =>
-        DoesNotExistError(exc)
-
-      case exc: AmazonS3Exception
-          if exc.getMessage.startsWith("The specified bucket is not valid") =>
-        StoreReadError(exc)
-
-      case exc: AmazonS3Exception
-          if exc.getMessage.startsWith(
-            "We encountered an internal error. Please try again.") ||
-            exc.getMessage.startsWith("Please reduce your request rate.") =>
-        new StoreReadError(exc) with RetryableError
-
-      case exc: SocketTimeoutException =>
-        new StoreReadError(exc) with RetryableError
-
-      case _ =>
-        warn(s"Unrecognised error inside S3StreamStore.get: $throwable")
-        StoreReadError(throwable)
-    }
+      }
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
@@ -1,9 +1,40 @@
 package uk.ac.wellcome.storage.tags
 
-import uk.ac.wellcome.storage.{ReadError, WriteError}
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.storage._
 
-trait Tags[Ident] {
+trait Tags[Ident] extends Logging {
   def get(id: Ident): Either[ReadError, Map[String, String]]
 
-  def put(id: Ident, tags: Map[String, String]): Either[WriteError, Map[String, String]]
+  protected def put(id: Ident, tags: Map[String, String]): Either[WriteError, Map[String, String]]
+
+  def update(id: Ident)(
+    updateFunction: Map[String, String] => Either[UpdateFunctionError, Map[String, String]]): Either[UpdateError, Map[String, String]] = {
+    info(s"Tags on $id: updating tags")
+
+    for {
+      existingTags <- get(id) match {
+        case Right(value) => Right(value)
+        case Left(err: DoesNotExistError) => Left(UpdateNoSourceError(err))
+        case Left(err)                    => Left(UpdateReadError(err))
+      }
+
+      _ = debug(s"Tags on $id: existing tags = $existingTags")
+
+      newTags <- updateFunction(existingTags)
+
+      _ = debug(s"Tags on $id: new tags      = $newTags")
+
+      result <- if (newTags == existingTags) {
+        debug(s"Tags on $id: no change, so skipping a write")
+        Right(existingTags)
+      } else {
+        debug(s"Tags on $id: tags have changed, so writing new tags")
+        put(id = id, tags = newTags) match {
+          case Right(value) => Right(value)
+          case Left(err)    => Left(UpdateWriteError(err))
+        }
+      }
+    } yield result
+  }
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
@@ -6,15 +6,19 @@ import uk.ac.wellcome.storage._
 trait Tags[Ident] extends Logging {
   def get(id: Ident): Either[ReadError, Map[String, String]]
 
-  protected def put(id: Ident, tags: Map[String, String]): Either[WriteError, Map[String, String]]
+  protected def put(
+    id: Ident,
+    tags: Map[String, String]): Either[WriteError, Map[String, String]]
 
   def update(id: Ident)(
-    updateFunction: Map[String, String] => Either[UpdateFunctionError, Map[String, String]]): Either[UpdateError, Map[String, String]] = {
+    updateFunction: Map[String, String] => Either[UpdateFunctionError,
+                                                  Map[String, String]])
+    : Either[UpdateError, Map[String, String]] = {
     info(s"Tags on $id: updating tags")
 
     for {
       existingTags <- get(id) match {
-        case Right(value) => Right(value)
+        case Right(value)                 => Right(value)
         case Left(err: DoesNotExistError) => Left(UpdateNoSourceError(err))
         case Left(err)                    => Left(UpdateReadError(err))
       }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/Tags.scala
@@ -1,0 +1,9 @@
+package uk.ac.wellcome.storage.tags
+
+import uk.ac.wellcome.storage.{ReadError, WriteError}
+
+trait Tags[Ident] {
+  def get(id: Ident): Either[ReadError, Map[String, String]]
+
+  def put(id: Ident, tags: Map[String, String]): Either[WriteError, Map[String, String]]
+}

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/memory/MemoryTags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/memory/MemoryTags.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.storage.tags.memory
+
+import uk.ac.wellcome.storage.{DoesNotExistError, ReadError, WriteError}
+import uk.ac.wellcome.storage.tags.Tags
+
+class MemoryTags[Ident](initialTags: Map[Ident, Map[String, String]]) extends Tags[Ident] {
+  private var underlying: Map[Ident, Map[String, String]] = initialTags
+
+  override def get(id: Ident): Either[ReadError, Map[String, String]] =
+    underlying.get(id) match {
+      case Some(tags) => Right(tags)
+      case None       => Left(DoesNotExistError())
+    }
+
+  override def put(id: Ident, tags: Map[String, String]): Either[WriteError, Map[String, String]] = {
+    underlying = underlying ++ Map(id -> tags)
+    Right(tags)
+  }
+}

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/memory/MemoryTags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/memory/MemoryTags.scala
@@ -3,20 +3,25 @@ package uk.ac.wellcome.storage.tags.memory
 import uk.ac.wellcome.storage.{DoesNotExistError, ReadError, WriteError}
 import uk.ac.wellcome.storage.tags.Tags
 
-class MemoryTags[Ident](initialTags: Map[Ident, Map[String, String]]) extends Tags[Ident] {
+class MemoryTags[Ident](initialTags: Map[Ident, Map[String, String]])
+    extends Tags[Ident] {
   private var underlying: Map[Ident, Map[String, String]] = initialTags
 
-  override def get(id: Ident): Either[ReadError, Map[String, String]] = synchronized {
-    underlying.get(id) match {
-      case Some(tags) => Right(tags)
-      case None => Left(DoesNotExistError())
+  override def get(id: Ident): Either[ReadError, Map[String, String]] =
+    synchronized {
+      underlying.get(id) match {
+        case Some(tags) => Right(tags)
+        case None       => Left(DoesNotExistError())
+      }
     }
-  }
 
-  override protected def put(id: Ident, tags: Map[String, String]): Either[WriteError, Map[String, String]] = synchronized {
-    debug(s"MemoryTags.put($id, $tags) before = $underlying")
-    underlying = underlying ++ Map(id -> tags)
-    debug(s"MemoryTags.put($id, $tags) after  = $underlying")
-    Right(tags)
-  }
+  override protected def put(
+    id: Ident,
+    tags: Map[String, String]): Either[WriteError, Map[String, String]] =
+    synchronized {
+      debug(s"MemoryTags.put($id, $tags) before = $underlying")
+      underlying = underlying ++ Map(id -> tags)
+      debug(s"MemoryTags.put($id, $tags) after  = $underlying")
+      Right(tags)
+    }
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/memory/MemoryTags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/memory/MemoryTags.scala
@@ -6,14 +6,17 @@ import uk.ac.wellcome.storage.tags.Tags
 class MemoryTags[Ident](initialTags: Map[Ident, Map[String, String]]) extends Tags[Ident] {
   private var underlying: Map[Ident, Map[String, String]] = initialTags
 
-  override def get(id: Ident): Either[ReadError, Map[String, String]] =
+  override def get(id: Ident): Either[ReadError, Map[String, String]] = synchronized {
     underlying.get(id) match {
       case Some(tags) => Right(tags)
-      case None       => Left(DoesNotExistError())
+      case None => Left(DoesNotExistError())
     }
+  }
 
-  override def put(id: Ident, tags: Map[String, String]): Either[WriteError, Map[String, String]] = {
+  override protected def put(id: Ident, tags: Map[String, String]): Either[WriteError, Map[String, String]] = synchronized {
+    debug(s"MemoryTags.put($id, $tags) before = $underlying")
     underlying = underlying ++ Map(id -> tags)
+    debug(s"MemoryTags.put($id, $tags) after  = $underlying")
     Right(tags)
   }
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/s3/S3Tags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/s3/S3Tags.scala
@@ -1,0 +1,29 @@
+package uk.ac.wellcome.storage.tags.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{GetObjectTaggingRequest, Tag}
+import uk.ac.wellcome.storage.s3.S3Get
+import uk.ac.wellcome.storage.{ObjectLocation, ReadError, WriteError}
+import uk.ac.wellcome.storage.tags.Tags
+
+import scala.collection.JavaConverters._
+
+class S3Tags(maxRetries: Int = 3)(implicit s3Client: AmazonS3) extends Tags[ObjectLocation] {
+  override def get(location: ObjectLocation): Either[ReadError, Map[String, String]] =
+    for {
+      response <- S3Get.get(location, maxRetries = maxRetries) {
+        location: ObjectLocation =>
+          s3Client.getObjectTagging(
+            new GetObjectTaggingRequest(location.namespace, location.path)
+          )
+      }
+
+      tags = response
+        .getTagSet
+        .asScala
+        .map { tag: Tag => tag.getKey -> tag.getValue }
+        .toMap
+    } yield tags
+
+  override protected def put(location: ObjectLocation, tags: Map[String, String]): Either[WriteError, Map[String, String]] = ???
+}

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/s3/S3Tags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/s3/S3Tags.scala
@@ -1,12 +1,13 @@
 package uk.ac.wellcome.storage.tags.s3
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.{GetObjectTaggingRequest, Tag}
+import com.amazonaws.services.s3.model.{GetObjectTaggingRequest, ObjectTagging, SetObjectTaggingRequest, Tag}
 import uk.ac.wellcome.storage.s3.S3Get
-import uk.ac.wellcome.storage.{ObjectLocation, ReadError, WriteError}
+import uk.ac.wellcome.storage.{ObjectLocation, ReadError, StoreWriteError, WriteError}
 import uk.ac.wellcome.storage.tags.Tags
 
 import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
 
 class S3Tags(maxRetries: Int = 3)(implicit s3Client: AmazonS3) extends Tags[ObjectLocation] {
   override def get(location: ObjectLocation): Either[ReadError, Map[String, String]] =
@@ -25,5 +26,23 @@ class S3Tags(maxRetries: Int = 3)(implicit s3Client: AmazonS3) extends Tags[Obje
         .toMap
     } yield tags
 
-  override protected def put(location: ObjectLocation, tags: Map[String, String]): Either[WriteError, Map[String, String]] = ???
+  override protected def put(location: ObjectLocation, tags: Map[String, String]): Either[WriteError, Map[String, String]] = {
+    val tagSet = tags
+      .map { case (k, v) => new Tag(k, v) }
+      .toSeq
+      .asJava
+
+    Try {
+      s3Client.setObjectTagging(
+        new SetObjectTaggingRequest(
+          location.namespace,
+          location.path,
+          new ObjectTagging(tagSet)
+        )
+      )
+    } match {
+      case Success(_)   => Right(tags)
+      case Failure(err) => Left(StoreWriteError(err))
+    }
+  }
 }

--- a/storage/src/main/scala/uk/ac/wellcome/storage/tags/s3/S3Tags.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/tags/s3/S3Tags.scala
@@ -1,16 +1,28 @@
 package uk.ac.wellcome.storage.tags.s3
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.{GetObjectTaggingRequest, ObjectTagging, SetObjectTaggingRequest, Tag}
+import com.amazonaws.services.s3.model.{
+  GetObjectTaggingRequest,
+  ObjectTagging,
+  SetObjectTaggingRequest,
+  Tag
+}
 import uk.ac.wellcome.storage.s3.S3Get
-import uk.ac.wellcome.storage.{ObjectLocation, ReadError, StoreWriteError, WriteError}
+import uk.ac.wellcome.storage.{
+  ObjectLocation,
+  ReadError,
+  StoreWriteError,
+  WriteError
+}
 import uk.ac.wellcome.storage.tags.Tags
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
-class S3Tags(maxRetries: Int = 3)(implicit s3Client: AmazonS3) extends Tags[ObjectLocation] {
-  override def get(location: ObjectLocation): Either[ReadError, Map[String, String]] =
+class S3Tags(maxRetries: Int = 3)(implicit s3Client: AmazonS3)
+    extends Tags[ObjectLocation] {
+  override def get(
+    location: ObjectLocation): Either[ReadError, Map[String, String]] =
     for {
       response <- S3Get.get(location, maxRetries = maxRetries) {
         location: ObjectLocation =>
@@ -19,14 +31,14 @@ class S3Tags(maxRetries: Int = 3)(implicit s3Client: AmazonS3) extends Tags[Obje
           )
       }
 
-      tags = response
-        .getTagSet
-        .asScala
-        .map { tag: Tag => tag.getKey -> tag.getValue }
-        .toMap
+      tags = response.getTagSet.asScala.map { tag: Tag =>
+        tag.getKey -> tag.getValue
+      }.toMap
     } yield tags
 
-  override protected def put(location: ObjectLocation, tags: Map[String, String]): Either[WriteError, Map[String, String]] = {
+  override protected def put(
+    location: ObjectLocation,
+    tags: Map[String, String]): Either[WriteError, Map[String, String]] = {
     val tagSet = tags
       .map { case (k, v) => new Tag(k, v) }
       .toSeq

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTest.scala
@@ -1,0 +1,62 @@
+package uk.ac.wellcome.storage.tags
+
+import java.util.UUID
+
+import org.scalatest.EitherValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.storage.generators.RandomThings
+import uk.ac.wellcome.storage.tags.memory.MemoryTags
+import uk.ac.wellcome.storage._
+
+class TagsTest extends AnyFunSpec with Matchers with EitherValues with RandomThings {
+  def createTags: Map[String, String] =
+    (1 to randomInt(from = 0, to = 25))
+      .map { _ =>
+        randomAlphanumeric -> randomAlphanumeric
+      }
+      .toMap
+
+  def createIdent: UUID = UUID.randomUUID()
+
+  describe("update()") {
+    it("wraps a ReadError from the underlying store") {
+      val readError = StoreReadError(new Throwable("BOOM!"))
+
+      class BrokenReadTags()
+        extends MemoryTags[UUID](initialTags = Map.empty) {
+        override def get(id: UUID): Either[ReadError, Map[String, String]] =
+          Left(readError)
+      }
+
+      val tags = new BrokenReadTags()
+
+      tags
+        .update(createIdent) {
+          existingTags => Right(existingTags ++ Map("myTag" -> "newValue"))
+        }
+        .left.value shouldBe UpdateReadError(readError)
+    }
+
+    it("wraps a WriteError from the underlying store") {
+      val writeError = StoreWriteError(new Throwable("BOOM!"))
+
+      class BrokenWriteTags(initialTags: Map[UUID, Map[String, String]])
+        extends MemoryTags[UUID](initialTags = initialTags) {
+        override protected def put(id: UUID, tags: Map[String, String]): Either[WriteError, Map[String, String]] =
+          Left(writeError)
+      }
+
+      val objectIdent = createIdent
+      val objectTags = createTags
+
+      val tags = new BrokenWriteTags(initialTags = Map(objectIdent -> objectTags))
+
+      tags
+        .update(objectIdent) {
+          existingTags => Right(existingTags ++ Map("myTag" -> "newValue"))
+        }
+        .left.value shouldBe UpdateWriteError(writeError)
+    }
+  }
+}

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
@@ -1,0 +1,40 @@
+package uk.ac.wellcome.storage.tags
+
+import org.scalatest.EitherValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.storage.DoesNotExistError
+import uk.ac.wellcome.storage.generators.RandomThings
+
+trait TagsTestCases[Ident] extends AnyFunSpec with Matchers with EitherValues with RandomThings {
+  def withTags[R](initialTags: Map[Ident, Map[String, String]])(testWith: TestWith[Tags[Ident], R]): R
+
+  def createIdent: Ident
+
+  def createTags: Map[String, String] =
+    (1 to randomInt(from = 0, to = 25))
+      .map { _ =>
+        randomAlphanumeric -> randomAlphanumeric
+      }
+      .toMap
+
+  describe("behaves as a Tags") {
+    describe("get()") {
+      it("can read the tags for an identifier") {
+        val objectIdent = createIdent
+        val objectTags = createTags
+
+        withTags(initialTags = Map(objectIdent -> objectTags)) { tags =>
+          tags.get(id = objectIdent).right.value shouldBe objectTags
+        }
+      }
+
+      it("returns a DoesNotExistError if the ident does nto exist") {
+        withTags(initialTags = Map.empty) { tags =>
+          tags.get(id = createIdent).left.value shouldBe a[DoesNotExistError]
+        }
+      }
+    }
+  }
+}

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
@@ -14,8 +14,9 @@ trait TagsTestCases[Ident, Context] extends AnyFunSpec with Matchers with Either
 
   val maxTags: Int = 25
 
+  // One less than maxTags so we can append to the tags further down
   def createTags: Map[String, String] =
-    (1 to randomInt(from = 0, to = maxTags))
+    (1 to randomInt(from = 0, to = maxTags - 1))
       .map { _ =>
         randomAlphanumeric -> randomAlphanumeric
       }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
@@ -7,106 +7,128 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.storage.{DoesNotExistError, UpdateNoSourceError, UpdateNotApplied}
 import uk.ac.wellcome.storage.generators.RandomThings
 
-trait TagsTestCases[Ident] extends AnyFunSpec with Matchers with EitherValues with RandomThings {
+trait TagsTestCases[Ident, Context] extends AnyFunSpec with Matchers with EitherValues with RandomThings {
   def withTags[R](initialTags: Map[Ident, Map[String, String]])(testWith: TestWith[Tags[Ident], R]): R
 
-  def createIdent: Ident
+  def createIdent(context: Context): Ident
+
+  val maxTags: Int = 25
 
   def createTags: Map[String, String] =
-    (1 to randomInt(from = 0, to = 25))
+    (1 to randomInt(from = 0, to = maxTags))
       .map { _ =>
         randomAlphanumeric -> randomAlphanumeric
       }
       .toMap
 
+  def withContext[R](testWith: TestWith[Context, R]): R
+
   describe("behaves as a Tags") {
     describe("get()") {
       it("can read the tags for an identifier") {
-        val objectIdent = createIdent
-        val objectTags = createTags
+        withContext { context =>
+          val objectIdent = createIdent(context)
+          val objectTags = createTags
 
-        withTags(initialTags = Map(objectIdent -> objectTags)) { tags =>
-          tags.get(id = objectIdent).right.value shouldBe objectTags
+          withTags(initialTags = Map(objectIdent -> objectTags)) { tags =>
+            tags.get(id = objectIdent).right.value shouldBe objectTags
+          }
         }
       }
 
-      it("returns a DoesNotExistError if the ident does nto exist") {
-        withTags(initialTags = Map.empty) { tags =>
-          tags.get(id = createIdent).left.value shouldBe a[DoesNotExistError]
+      it("returns a DoesNotExistError if the ident does not exist") {
+        withContext { context =>
+          withTags(initialTags = Map.empty) { tags =>
+            tags.get(id = createIdent(context)).left.value shouldBe a[DoesNotExistError]
+          }
         }
       }
     }
 
     describe("update()") {
       it("appends to the tags on an object") {
-        val objectIdent = createIdent
-        val objectTags = createTags
+        withContext { context =>
+          val objectIdent = createIdent(context)
+          val objectTags = createTags
 
-        val newTag = Map("myTag" -> "newTag")
+          val newTag = Map("myTag" -> "newTag")
 
-        withTags(initialTags = Map(objectIdent -> objectTags)) { tags =>
-          tags
-            .update(id = objectIdent) { existingTags =>
-              Right(existingTags ++ newTag)
-            }
-            .right.value shouldBe objectTags ++ newTag
+          withTags(initialTags = Map(objectIdent -> objectTags)) { tags =>
+            tags
+              .update(id = objectIdent) { existingTags =>
+                Right(existingTags ++ newTag)
+              }
+              .right.value shouldBe objectTags ++ newTag
 
-          tags.get(id = objectIdent).right.value shouldBe objectTags ++ newTag
+            tags.get(id = objectIdent).right.value shouldBe objectTags ++ newTag
+          }
         }
       }
 
       it("can delete tags on an object") {
-        val objectIdent = createIdent
-        val objectTags = createTags
+        withContext { context =>
+          val objectIdent = createIdent(context)
+          val objectTags = createTags
 
-        withTags(initialTags = Map(objectIdent -> objectTags)) { tags =>
-          tags
-            .update(id = objectIdent) { existingTags =>
-              Right(Map.empty)
-            }
-            .right.value shouldBe Map.empty
+          withTags(initialTags = Map(objectIdent -> objectTags)) { tags =>
+            tags
+              .update(id = objectIdent) { existingTags =>
+                Right(Map.empty)
+              }
+              .right.value shouldBe Map.empty
 
-          tags.get(id = objectIdent).right.value shouldBe Map.empty
+            tags.get(id = objectIdent).right.value shouldBe Map.empty
+          }
         }
       }
 
       it("doesn't change the tags if the update function returns a Left()") {
-        val objectIdent = createIdent
-        val objectTags = createTags
+        withContext { context =>
+          val objectIdent = createIdent(context)
+          val objectTags = createTags
 
-        withTags(initialTags = Map(objectIdent -> objectTags)) { tags =>
-          tags
-            .update(id = objectIdent) { _ =>
-              Left(UpdateNotApplied(new Throwable("BOOM!")))
-            }
-            .left.value shouldBe a[UpdateNotApplied]
+          withTags(initialTags = Map(objectIdent -> objectTags)) { tags =>
+            tags
+              .update(id = objectIdent) { _ =>
+                Left(UpdateNotApplied(new Throwable("BOOM!")))
+              }
+              .left.value shouldBe a[UpdateNotApplied]
 
-          tags.get(id = objectIdent).right.value shouldBe objectTags
+            tags.get(id = objectIdent).right.value shouldBe objectTags
+          }
         }
       }
 
       it("can apply a no-op update on tags") {
-        val objectIdent = createIdent
-        val objectTags = createTags
+        withContext { context =>
+          val objectIdent = createIdent(context)
+          val objectTags = createTags
 
-        withTags(initialTags = Map(objectIdent -> objectTags)) { tags =>
-          tags
-            .update(id = objectIdent) { Right(_) }
-            .right.value shouldBe objectTags
+          withTags(initialTags = Map(objectIdent -> objectTags)) { tags =>
+            tags
+              .update(id = objectIdent) {
+                Right(_)
+              }
+              .right.value shouldBe objectTags
 
-          tags.get(id = objectIdent).right.value shouldBe objectTags
+            tags.get(id = objectIdent).right.value shouldBe objectTags
+          }
         }
       }
 
       it("returns an UpdateSourceError if the ident does not exist") {
-        val objectIdent = createIdent
+        withContext { context =>
+          val objectIdent = createIdent(context)
 
-        withTags(initialTags = Map.empty) { tags =>
-          tags
-            .update(id = objectIdent) { Right(_) }
-            .left.value shouldBe a[UpdateNoSourceError]
+          withTags(initialTags = Map.empty) { tags =>
+            tags
+              .update(id = objectIdent) {
+                Right(_)
+              }
+              .left.value shouldBe a[UpdateNoSourceError]
 
-          tags.get(id = objectIdent).left.value shouldBe a[DoesNotExistError]
+            tags.get(id = objectIdent).left.value shouldBe a[DoesNotExistError]
+          }
         }
       }
     }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/TagsTestCases.scala
@@ -36,5 +36,28 @@ trait TagsTestCases[Ident] extends AnyFunSpec with Matchers with EitherValues wi
         }
       }
     }
+
+    describe("put()") {
+      it("can write new tags to an identifier") {
+        val objectIdent = createIdent
+        val objectTags = createTags
+
+        withTags(initialTags = Map(objectIdent -> Map.empty)) { tags =>
+          tags.put(id = objectIdent, tags = objectTags) shouldBe Right(objectTags)
+          tags.get(id = objectIdent).right.value shouldBe objectTags
+        }
+      }
+
+      it("replaces the existing tags for an identifier") {
+        val objectIdent = createIdent
+        val oldTags = createTags
+        val newTags = createTags
+
+        withTags(initialTags = Map(objectIdent -> oldTags)) { tags =>
+          tags.put(id = objectIdent, tags = newTags) shouldBe Right(newTags)
+          tags.get(id = objectIdent).right.value shouldBe newTags
+        }
+      }
+    }
   }
 }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/memory/MemoryTagsTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/memory/MemoryTagsTest.scala
@@ -1,0 +1,15 @@
+package uk.ac.wellcome.storage.tags.memory
+
+import java.util.UUID
+
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.storage.tags.{Tags, TagsTestCases}
+
+class MemoryTagsTest extends TagsTestCases[UUID] {
+  override def withTags[R](initialTags: Map[UUID, Map[String, String]])(testWith: TestWith[Tags[UUID], R]): R =
+    testWith(
+      new MemoryTags(initialTags)
+    )
+
+  override def createIdent: UUID = UUID.randomUUID()
+}

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/memory/MemoryTagsTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/memory/MemoryTagsTest.scala
@@ -5,11 +5,13 @@ import java.util.UUID
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.storage.tags.{Tags, TagsTestCases}
 
-class MemoryTagsTest extends TagsTestCases[UUID] {
+class MemoryTagsTest extends TagsTestCases[UUID, Unit] {
   override def withTags[R](initialTags: Map[UUID, Map[String, String]])(testWith: TestWith[Tags[UUID], R]): R =
     testWith(
       new MemoryTags(initialTags)
     )
 
-  override def createIdent: UUID = UUID.randomUUID()
+  override def createIdent(context: Unit): UUID = UUID.randomUUID()
+
+  override def withContext[R](testWith: TestWith[Unit, R]): R = testWith(())
 }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/s3/S3TagsTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/s3/S3TagsTest.scala
@@ -1,0 +1,48 @@
+package uk.ac.wellcome.storage.tags.s3
+
+import com.amazonaws.services.s3.model._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.tags.{Tags, TagsTestCases}
+
+import scala.collection.JavaConverters._
+
+class S3TagsTest extends AnyFunSpec with Matchers with TagsTestCases[ObjectLocation, Bucket] with S3Fixtures {
+  // We can associate with at most 10 tags on an object; see
+  // https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html
+  override val maxTags: Int = 10
+
+  override def withTags[R](initialTags: Map[ObjectLocation, Map[String, String]])(testWith: TestWith[Tags[ObjectLocation], R]): R = {
+    initialTags
+      .foreach { case (location, tags) =>
+        s3Client.putObject(location.namespace, location.path, randomAlphanumeric)
+
+        val tagSet = tags
+          .map { case (k, v) => new Tag(k, v) }
+          .toSeq
+          .asJava
+
+        s3Client.setObjectTagging(
+          new SetObjectTaggingRequest(
+            location.namespace,
+            location.path,
+            new ObjectTagging(tagSet)
+          )
+        )
+      }
+
+    testWith(new S3Tags())
+  }
+
+  override def createIdent(bucket: Bucket): ObjectLocation =
+    createObjectLocationWith(bucket)
+
+  override def withContext[R](testWith: TestWith[Bucket, R]): R =
+    withLocalS3Bucket { bucket =>
+      testWith(bucket)
+    }
+}

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/s3/S3TagsTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/s3/S3TagsTest.scala
@@ -21,7 +21,7 @@ class S3TagsTest extends AnyFunSpec with Matchers with TagsTestCases[ObjectLocat
   override def withTags[R](initialTags: Map[ObjectLocation, Map[String, String]])(testWith: TestWith[Tags[ObjectLocation], R]): R = {
     initialTags
       .foreach { case (location, tags) =>
-        s3Client.putObject(location.namespace, location.path, randomAlphanumeric)
+        putObject(location)
 
         val tagSet = tags
           .map { case (k, v) => new Tag(k, v) }
@@ -60,7 +60,7 @@ class S3TagsTest extends AnyFunSpec with Matchers with TagsTestCases[ObjectLocat
 
       withLocalS3Bucket { bucket =>
         val location = createObjectLocationWith(bucket)
-        s3Client.putObject(location.namespace, location.path, randomAlphanumeric)
+        putObject(location)
 
         val result =
           s3Tags
@@ -77,7 +77,7 @@ class S3TagsTest extends AnyFunSpec with Matchers with TagsTestCases[ObjectLocat
     it("if the tag name is empty") {
       withLocalS3Bucket { bucket =>
         val location = createObjectLocationWith(bucket)
-        s3Client.putObject(location.namespace, location.path, randomAlphanumeric)
+        putObject(location)
 
         val result =
           s3Tags
@@ -96,7 +96,7 @@ class S3TagsTest extends AnyFunSpec with Matchers with TagsTestCases[ObjectLocat
       // https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html
       withLocalS3Bucket { bucket =>
         val location = createObjectLocationWith(bucket)
-        s3Client.putObject(location.namespace, location.path, randomAlphanumeric)
+        putObject(location)
 
         val result =
           s3Tags
@@ -115,7 +115,7 @@ class S3TagsTest extends AnyFunSpec with Matchers with TagsTestCases[ObjectLocat
       // https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html
       withLocalS3Bucket { bucket =>
         val location = createObjectLocationWith(bucket)
-        s3Client.putObject(location.namespace, location.path, randomAlphanumeric)
+        putObject(location)
 
         val result =
           s3Tags
@@ -129,6 +129,9 @@ class S3TagsTest extends AnyFunSpec with Matchers with TagsTestCases[ObjectLocat
       }
     }
   }
+
+  private def putObject(location: ObjectLocation): Unit =
+    s3Client.putObject(location.namespace, location.path, s"<Written by ${this.getClass.getName}")
 
   private def assertIsS3Exception(result: Either[UpdateError, Map[String, String]])(assert: String => Assertion): Assertion = {
     val err = result.left.value

--- a/storage/src/test/scala/uk/ac/wellcome/storage/tags/s3/S3TagsTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/tags/s3/S3TagsTest.scala
@@ -1,15 +1,17 @@
 package uk.ac.wellcome.storage.tags.s3
 
 import com.amazonaws.services.s3.model._
+import org.scalatest.Assertion
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.{ObjectLocation, UpdateError, UpdateWriteError}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.tags.{Tags, TagsTestCases}
 
 import scala.collection.JavaConverters._
+import scala.util.Random
 
 class S3TagsTest extends AnyFunSpec with Matchers with TagsTestCases[ObjectLocation, Bucket] with S3Fixtures {
   // We can associate with at most 10 tags on an object; see
@@ -45,4 +47,97 @@ class S3TagsTest extends AnyFunSpec with Matchers with TagsTestCases[ObjectLocat
     withLocalS3Bucket { bucket =>
       testWith(bucket)
     }
+
+  val s3Tags = new S3Tags()
+
+  describe("handles S3-specific errors") {
+    // We can associate with at most 10 tags on an object; see
+    // https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html
+    it("if you send more than 10 tags") {
+      val newTags = (1 to 11)
+        .map { i => s"key-$i" -> s"value-$i" }
+        .toMap
+
+      withLocalS3Bucket { bucket =>
+        val location = createObjectLocationWith(bucket)
+        s3Client.putObject(location.namespace, location.path, randomAlphanumeric)
+
+        val result =
+          s3Tags
+            .update(location) { existingTags: Map[String, String] =>
+              Right(existingTags ++ newTags)
+            }
+
+        assertIsS3Exception(result) {
+          _ should startWith("Object tags cannot be greater than 10")
+        }
+      }
+    }
+
+    it("if the tag name is empty") {
+      withLocalS3Bucket { bucket =>
+        val location = createObjectLocationWith(bucket)
+        s3Client.putObject(location.namespace, location.path, randomAlphanumeric)
+
+        val result =
+          s3Tags
+            .update(location) { existingTags: Map[String, String] =>
+              Right(existingTags ++ Map("" -> "value"))
+            }
+
+        assertIsS3Exception(result) {
+          _ should startWith("The TagKey you have provided is invalid")
+        }
+      }
+    }
+
+    it("if the tag name is too long") {
+      // A tag key can be at most 128 characters long.
+      // https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html
+      withLocalS3Bucket { bucket =>
+        val location = createObjectLocationWith(bucket)
+        s3Client.putObject(location.namespace, location.path, randomAlphanumeric)
+
+        val result =
+          s3Tags
+            .update(location) { existingTags: Map[String, String] =>
+              Right(existingTags ++ Map(randomAlphanumericWithLength(129) -> "value"))
+            }
+
+        assertIsS3Exception(result) {
+          _ should startWith("The TagKey you have provided is invalid")
+        }
+      }
+    }
+
+    it("if the tag value is too long") {
+      // A tag value can be at most 256 characters long.
+      // https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html
+      withLocalS3Bucket { bucket =>
+        val location = createObjectLocationWith(bucket)
+        s3Client.putObject(location.namespace, location.path, randomAlphanumeric)
+
+        val result =
+          s3Tags
+            .update(location) { existingTags: Map[String, String] =>
+              Right(existingTags ++ Map("key" -> randomAlphanumericWithLength(257)))
+            }
+
+        assertIsS3Exception(result) {
+          _ should startWith("The TagValue you have provided is invalid")
+        }
+      }
+    }
+  }
+
+  private def assertIsS3Exception(result: Either[UpdateError, Map[String, String]])(assert: String => Assertion): Assertion = {
+    val err = result.left.value
+
+    err shouldBe a[UpdateWriteError]
+    err.e shouldBe a[AmazonS3Exception]
+    assert(err.e.getMessage)
+  }
+
+  def randomAlphanumericWithLength(length: Int): String =
+    Random.alphanumeric take length mkString
 }


### PR DESCRIPTION
Add a new abstract trait `Tags` for managing tags, with in-memory and S3 implementations. Examples in the release note.